### PR TITLE
Remove empty element from split() when app_sg_ids is empty

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_security_group" "rds_sg" {
 }
 
 resource "aws_security_group_rule" "allow_connect_from_app" {
-  count           = "${length(split(",", var.app_sg_ids))}"
+  count           = "${length(compact(split(",", var.app_sg_ids)))}"
   type            = "ingress"
   from_port       = "${lookup(var.rds_ports, var.rds_engine_name)}"
   to_port         = "${lookup(var.rds_ports, var.rds_engine_name)}"


### PR DESCRIPTION
The error happened when var.app_sg_ids is in default value (`""`) and put it into `source_security_group_id`

Error message:
```
module.hk_postgresql.aws_security_group_rule.allow_connect_from_app: Creating...
  from_port:                "" => "5432"
  protocol:                 "" => "tcp"
  security_group_id:        "" => "sg-xxx"
  self:                     "" => "false"
  source_security_group_id: "" => "<computed>"
  to_port:                  "" => "5432"
  type:                     "" => "ingress"
Error applying plan:

1 error(s) occurred:

* module.hk_postgresql.aws_security_group_rule.allow_connect_from_app: 1 error(s) occurred:

* aws_security_group_rule.allow_connect_from_app: One of ['cidr_blocks', 'ipv6_cidr_blocks', 'self', 'source_security_group_id', 'prefix_list_ids'] must be set to create an AWS Security Group Rule

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```
---

To solve this, we need to remove empty element in the list after `split()` by [compact(list)](https://www.terraform.io/docs/configuration/interpolation.html#compact-list-)

Before
```
> length(split(",", ""))
1
> split(",", "")
[

]
```

After
```
> length(compact(split(",", "")))
0
> compact(split(",", ""))
[]
```